### PR TITLE
JSON arrays in script tags

### DIFF
--- a/src/parsers/jsonld-parser.js
+++ b/src/parsers/jsonld-parser.js
@@ -7,10 +7,15 @@ export default function (html, config = {}) {
 
   $html('script[type="application/ld+json"]').each((index, item) => {
     try {
-      const parsedJSON = JSON.parse($(item).text())
-      const type = parsedJSON['@type']
-      jsonldData[type] = jsonldData[type] || []
-      jsonldData[type].push(parsedJSON)
+      let parsedJSON = JSON.parse($(item).text())
+      if (!Array.isArray(parsedJSON)) {
+        parsedJSON = [parsedJSON]
+      }
+      parsedJSON.forEach(obj => {
+        const type = obj['@type']
+        jsonldData[type] = jsonldData[type] || []
+        jsonldData[type].push(obj)
+      })
     } catch (e) {
       console.log(`Error in jsonld parse - ${e}`)
     }

--- a/test/resources/expectedResult.json
+++ b/test/resources/expectedResult.json
@@ -146,6 +146,28 @@
           }
         }
       }
+    ],
+    "TheaterEvent": [
+      {
+        "@context": "http://schema.org",
+        "@type": "TheaterEvent",
+        "name": "Random Theater Show #1",
+        "startDate": "2016-12-15T19:30:00-06:00",
+        "location": {
+          "@type": "Place",
+          "name": "Theatre"
+        }
+      },
+      {
+        "@context": "http://schema.org",
+        "@type": "TheaterEvent",
+        "name": "Random Theater Show #2",
+        "startDate": "2016-12-16T19:30:00-06:00",
+        "location": {
+          "@type": "Place",
+          "name": "Theatre"
+        }
+      }
     ]
   }
 }

--- a/test/resources/testPage.html
+++ b/test/resources/testPage.html
@@ -29,6 +29,30 @@
   }
 }
 </script>
+<script type="application/ld+json">
+[
+  {
+    "@context":"http://schema.org",
+    "@type":"TheaterEvent",
+    "name":"Random Theater Show #1",
+    "startDate":"2016-12-15T19:30:00-06:00",
+    "location":{
+      "@type":"Place",
+      "name":"Theatre"
+    }
+  },
+  {
+    "@context":"http://schema.org",
+    "@type":"TheaterEvent",
+    "name":"Random Theater Show #2",
+    "startDate":"2016-12-16T19:30:00-06:00",
+    "location":{
+      "@type":"Place",
+      "name":"Theatre"
+    }
+  }
+]
+</script>
 <div itemscope itemtype="http://schema.org/Product">
   <span itemprop="brand">ACME</span>
   <span itemprop="name">Executive Anvil</span>


### PR DESCRIPTION
Some sites, e.g., [ticketmaster.com](http://www1.ticketmaster.com/jersey-boys-touring-new-orleans-louisiana-12-15-2016/event/1B005108E9DC7C10?artistid=1551009&majorcatid=10002&minorcatid=207&f_tmol_checkout=true&f_sessioncam=1&ab=m_efeat4101Mainv2desktop), use arrays inside JSON-LD script tags. Up to now, this was not supported, this pull request changes that.